### PR TITLE
共有テーブル設定時にアラーム通知トリガーがエラーになるバグの修正

### DIFF
--- a/app/packages/core/__tests__/infra/dynamodb-trash-schedule-repository.test.mts
+++ b/app/packages/core/__tests__/infra/dynamodb-trash-schedule-repository.test.mts
@@ -42,7 +42,7 @@ describe('DynamoDBTrashScheduleRepository', () => {
                 }
             );
 
-            ddbMock.on(GetCommand, { TableName: shared_table_name, Key: { id: shared_id } }).resolves(
+            ddbMock.on(GetCommand, { TableName: shared_table_name, Key: { shared_id: shared_id } }).resolves(
                 {
                     Item: { id: shared_id, description: description },
                     $metadata: { httpStatusCode: 200 }
@@ -77,7 +77,7 @@ describe('DynamoDBTrashScheduleRepository', () => {
                 }
             );
 
-            ddbMock.on(GetCommand, { TableName: shared_table_name, Key: { id: shared_id } }).resolves({
+            ddbMock.on(GetCommand, { TableName: shared_table_name, Key: { shared_id: shared_id } }).resolves({
                 $metadata: { httpStatusCode: 200 }
             });
 
@@ -108,7 +108,7 @@ describe('DynamoDBTrashScheduleRepository', () => {
                 $metadata: { httpStatusCode: 200 }
             });
 
-            ddbMock.on(GetCommand, { TableName: shared_table_name, Key: { id: shared_id } }).resolves({
+            ddbMock.on(GetCommand, { TableName: shared_table_name, Key: { shared_id: shared_id } }).resolves({
                 $metadata: { httpStatusCode: 500 }
             });
 

--- a/app/packages/core/src/infra/dynamodb-trash-schedule-repository.mts
+++ b/app/packages/core/src/infra/dynamodb-trash-schedule-repository.mts
@@ -30,7 +30,7 @@ export class DynamoDBTrashScheduleRepository implements TrashScheduleRepository 
         const sharedInput = {
           TableName: this.shared_table_name,
           Key: {
-            id: result.Item.shared_id
+            shared_id: result.Item.shared_id
           }
         };
         console.debug(sharedInput);


### PR DESCRIPTION
- throwtrash-shared-scheduleテーブルのパーティションキー誤り