### PR TITLE
Add delete alarm data functionality

### DIFF
--- a/app/packages/delete/src/index.mts
+++ b/app/packages/delete/src/index.mts
@@ -1,0 +1,28 @@
+import { DynamoDBClientConfig } from '@aws-sdk/client-dynamodb';
+import { SQSEvent, SQSHandler, Context } from 'aws-lambda';
+import 'source-map-support/register.js'
+import { deleteAlarmsFailedForOver30Days } from '@shared/core/usecase/alarm-service.mjs';
+import { ArgumentError } from '@shared/core/entity/argument-error.mjs';
+import { DynamoDBAlarmRepository } from '@shared/core/infra/dynamodb-alarm-repository.mjs';
+
+export const handler: SQSHandler = async (event: SQSEvent, _context: Context) => {
+    try {
+        const dynamoDBConfig: DynamoDBClientConfig = {
+            region: 'ap-northeast-1'
+        };
+        const alarmRepository = new DynamoDBAlarmRepository(dynamoDBConfig, process.env.ALARM_TABLE_NAME!);
+
+        for (const record of event.Records) {
+            const { newest_failed_time } = JSON.parse(record.body);
+            const newestFailedTime = new Date(newest_failed_time);
+
+            await deleteAlarmsFailedForOver30Days(alarmRepository, newestFailedTime);
+        }
+    } catch (error: any) {
+        if(error instanceof ArgumentError) {
+            console.error('アラームの削除に失敗しました。', error.message || '不明なエラーが発生しました');
+        } else {
+            console.error('アラームの削除に失敗しました。', error.message || '不明なエラーが発生しました');
+        }
+    }
+};

--- a/infra/alarm-delete/cloudwatch.tf
+++ b/infra/alarm-delete/cloudwatch.tf
@@ -1,0 +1,7 @@
+resource "aws_cloudwatch_log_group" "throwtrash-alarm-delete-log-group" {
+  name = "/aws/lambda/throwtrash-alarm-delete"
+  tags = local.tags
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}

--- a/infra/alarm-delete/iam.tf
+++ b/infra/alarm-delete/iam.tf
@@ -1,0 +1,69 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "lambda_assume_role_policy" {
+    statement {
+        actions = ["sts:AssumeRole"]
+        principals {
+            type        = "Service"
+            identifiers = ["lambda.amazonaws.com"]
+        }
+    }
+}
+
+resource "aws_iam_role" "throwtrash-alarm-delete-lambda-role" {
+    name               = "throwtrash-alarm-delete-lambda-role"
+    assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
+    tags = local.tags
+}
+
+resource "aws_iam_policy" "throwtrash-alarm-delete-lambda-policy" {
+    name   = "throwtrash-alarm-delete-lambda-policy"
+    policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "DynamoDBPolicy",
+            "Action": [
+                "dynamodb:*"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "${var.alarm_table_arn}",
+                "${var.alarm_table_arn}/*"
+            ]
+        },
+        {
+            "Sid": "SQSPolicy",
+            "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "${aws_sqs_queue.alarm_delete_queue.arn}"
+            ]
+        },
+        {
+            "Sid": "CloudWatchPolicy",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": [
+                "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${aws_lambda_function.throwtrash-alarm-delete-lambda.function_name}:*"
+            ]
+        }
+    ]
+}
+EOF
+    tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda-policy-attachment" {
+    role = aws_iam_role.throwtrash-alarm-delete-lambda-role.name
+    policy_arn = aws_iam_policy.throwtrash-alarm-delete-lambda-policy.arn
+}

--- a/infra/alarm-delete/lambda.tf
+++ b/infra/alarm-delete/lambda.tf
@@ -1,0 +1,45 @@
+data "archive_file" "delete-function-zip" {
+  type        = "zip"
+  source_dir  = "${path.root}/../app/packages/delete/dist"
+  output_path = "${path.module}/alarm-delete.zip"
+}
+
+resource "aws_lambda_function" "throwtrash-alarm-delete-lambda" {
+  function_name = "throwtrash-alarm-delete"
+  role          = aws_iam_role.throwtrash-alarm-delete-lambda-role.arn
+  handler       = "index.handler"
+
+  filename         = data.archive_file.delete-function-zip.output_path
+  source_code_hash = data.archive_file.delete-function-zip.output_base64sha256
+
+  runtime = "nodejs20.x"
+
+  layers = [var.layer_arn]
+
+  publish = var.environment == "prod"
+
+  environment {
+    variables = {
+      ALARM_TABLE_NAME = var.alarm_table_name
+    }
+  }
+
+  logging_config {
+    log_format = "JSON"
+    log_group  = aws_cloudwatch_log_group.throwtrash-alarm-delete-log-group.name
+  }
+
+  tags = local.tags
+}
+
+resource "aws_lambda_event_source_mapping" "sqs_event_source" {
+  event_source_arn = aws_sqs_queue.alarm_delete_queue.arn
+  function_name    = aws_lambda_function.throwtrash-alarm-delete-lambda.arn
+  batch_size       = 10
+  enabled          = true
+}
+
+resource "aws_sqs_queue" "alarm_delete_queue" {
+  name = "throwtrash-alarm-delete-queue"
+  tags = local.tags
+}


### PR DESCRIPTION
Implement a process to delete alarm data for devices that have failed to send messages for over 30 days.

* **New Lambda Function and SQS Configuration**
  - Add `infra/alarm-delete/lambda.tf` to create a new Lambda function for deleting alarm data based on the 30-day failure condition.
  - Add `infra/alarm-delete/iam.tf` to define IAM policies for the new Lambda function to access DynamoDB and SQS.
  - Add `infra/alarm-delete/cloudwatch.tf` to create a CloudWatch log group for the new Lambda function.

* **Lambda Function Implementation**
  - Add `app/packages/delete/src/index.mts` to implement the Lambda function that checks the 30-day failure condition before deleting alarm data.

* **Trigger Service Update**
  - Modify `app/packages/core/src/usecase/trigger-service.mts` to send an SQS message when a message fails to send, triggering the new Lambda function.

